### PR TITLE
Add context menu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ which handler to call based on the received `Interaction`.
 
 ```js
 const {
+    ApplicationCommandType,
     SlashCommandRegistry,
     // Can also import these directly, but you don't need them
+    // ContextMenuCommandBuilder,
     // SlashCommandBuilder,
     // SlashCommandSubcommandBuilder,
     // SlashCommandSubcommandGroupBuilder,
@@ -67,6 +69,11 @@ const commands = new SlashCommandRegistry()
                 .setHandler(interaction => interaction.reply('User info'))
             )
         )
+    )
+    .addContextMenuCommand(command => command
+        .setName('select')
+        .setType(ApplicationCommandType.Message)
+        .setHandler(interaction => interaction.reply('selected a message'))
     );
 ```
 

--- a/test.js
+++ b/test.js
@@ -16,6 +16,7 @@ const {
 	Interaction,
 } = require('discord.js');
 const {
+	ContextMenuCommandBuilder,
 	Options,
 	SlashCommandRegistry,
 	SlashCommandBuilder,
@@ -80,6 +81,41 @@ describe('SlashCommandRegistry addCommand()', function() {
 		expect(() => this.registry.addCommand(builder => 'thing')).to.throw(
 			Error, 'input did not resolve to a SlashCommandBuilder. Got thing'
 		);
+	});
+});
+
+describe('SlashCommandRegistry addContextMenuCommand()', function() {
+
+	beforeEach(function() {
+		this.registry = new SlashCommandRegistry();
+	});
+
+	it('Add builder instance', function() {
+		const builder = new ContextMenuCommandBuilder();
+		expect(() => this.registry.addContextMenuCommand(builder)).to.not.throw();
+		expect(this.registry.commands).to.include(builder);
+	});
+
+	it('value must be a builder', function() {
+		expect(() => this.registry.addContextMenuCommand('thing')).to.throw(
+			Error, 'input did not resolve to a ContextMenuCommandBuilder. Got thing'
+		);
+	});
+
+	it('Function returns builder', function() {
+		expect(this.registry.commands).to.be.empty;
+		expect(
+			() => this.registry.addContextMenuCommand(builder => builder)
+		).to.not.throw();
+		expect(this.registry.commands).to.have.lengthOf(1);
+	});
+
+	it('Function must return a builder', function() {
+		expect(
+			() => this.registry.addContextMenuCommand(builder => 'thing')
+		).to.throw(
+			Error, 'input did not resolve to a ContextMenuCommandBuilder. Got thing'
+		)
 	});
 });
 


### PR DESCRIPTION
Building this off of #3. This adds support for defining context menu commands.

As far as I can tell, the difference between a slash command and a context menu command is only relevant in the Discord UI itself. Bots seem to handle them all the same way, so we don't need to do much to support these too.