### PR TITLE
Emoji option resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This library simplifies this process by letting you do this all in one place.
 
 It also provides some bridging functionality to support additional option types:
 - Application
+- Emoji
 
 ## Usage
 
@@ -169,7 +170,11 @@ Discord (and Discord.js) does not currently support command options for things
 like Applications. This library provides functions to approximate these
 additional option types:
 
-- `getApplication(interaction, option_name)`
+- `getApplication(interaction, option_name, required=false)`
+- `getEmoji(interaction, option_name, required=false)`
+
+To use these, register the option as a string option, then use the
+`Options.getX(...)` helpers to retrieve the value.
 
 For example, this is a functional example of an Application option:
 

--- a/index.js
+++ b/index.js
@@ -349,12 +349,14 @@ class SlashCommandRegistry {
  * @param {CommandInteraction} interaction A Discord.js interaction containing a
  *   string option containing an application's ID.
  * @param {String} opt_name The option containing the application's ID.
+ * @param {Boolean} required Whether to throw an error if the option is not
+ *   found (default false).
  * @return {Promise<Application>} Fulfills based on the Discord API call.
  * @resolve {@link Application} The resolved Application object.
  * @reject Any error from the Discord API, e.g. invalid application ID.
  */
-function getApplication(interaction, opt_name) {
-	const app_id = interaction.options.getString(opt_name);
+async function getApplication(interaction, opt_name, required=false) {
+	const app_id = interaction.options.getString(opt_name, required);
 	return new REST({ version: '9' })
 		.setToken('ignored')
 		.get(`/applications/${app_id}/rpc`) // NOTE: undocumented endpoint!
@@ -372,7 +374,8 @@ const CUSTOM_EMOJI_PATTERN = /^<a?:[^:]+:(\d{17,22})>$/;
  * @param {CommandInteraction} interaction A Discord.js interaction containing a
  *   string option that contains an emoji.
  * @param {String} opt_name The option containing the Emoji.
- * @param {Boolean} required Whether to throw an error if the option is not found.
+ * @param {Boolean} required Whether to throw an error if the option is not
+ *   found (default false).
  * @return {GuildEmoji|String|null} The resolved emoji as a Discord.js
  *   GuildEmoji object for custom emojis, as a String for built-in emojis, or
  *   null if not found.

--- a/test.js
+++ b/test.js
@@ -477,18 +477,18 @@ describe('SlashCommandRegistry execute()', function() {
 });
 
 describe('Option resolvers', function() {
+	const test_opt_name = 'test_opt';
+	function makeInteractionWithOpt(opt) {
+		return new MockCommandInteraction({
+			name: 'test',
+			string_opts: { [test_opt_name]: opt },
+		});
+	}
 
 	describe('getApplication()', function() {
-		const test_opt_name = 'app_id';
-		function makeInteractionWithAppId(app_id) {
-			return new MockCommandInteraction({
-				name: 'test',
-				string_opts: { [test_opt_name]: app_id },
-			});
-		}
 
 		it('Required but not provided', function() {
-			const interaction = makeInteractionWithAppId(undefined);
+			const interaction = makeInteractionWithOpt(undefined);
 			return Options.getApplication(interaction, test_opt_name, true)
 				.then(() => expect.fail('Expected exception but got none'))
 				.catch(err => {
@@ -507,7 +507,7 @@ describe('Option resolvers', function() {
 					name: test_app_name,
 					icon: 'testhashthinghere',
 				});
-			const interaction = makeInteractionWithAppId(test_app_id);
+			const interaction = makeInteractionWithOpt(test_app_id);
 
 			return Options.getApplication(interaction, test_opt_name).then(app => {
 				expect(app).to.be.instanceOf(Application);
@@ -518,36 +518,29 @@ describe('Option resolvers', function() {
 	});
 
 	describe('getEmoji()', function() {
-		const test_opt_name = 'emoji';
-		function makeInteractionWithEmoji(str) {
-			return new MockCommandInteraction({
-				name: 'test',
-				string_opts: { [test_opt_name]: str },
-			});
-		}
 
 		it('Required but not provided', function() {
-			const interaction = makeInteractionWithEmoji(undefined);
+			const interaction = makeInteractionWithOpt(undefined);
 			expect(
 				() => Options.getEmoji(interaction, test_opt_name, true)
 			).to.throw(TypeError, /expected a non-empty value/);
 		});
 
 		it('Optional and not provided', function() {
-			const interaction = makeInteractionWithEmoji(undefined);
+			const interaction = makeInteractionWithOpt(undefined);
 			const emoji = Options.getEmoji(interaction, test_opt_name);
 			expect(emoji).to.be.null;
 		});
 
 		it('Not an emoji string', function() {
-			const interaction = makeInteractionWithEmoji('not an emoji');
+			const interaction = makeInteractionWithOpt('not an emoji');
 			const emoji = Options.getEmoji(interaction, test_opt_name);
 			expect(emoji).to.be.null;
 		});
 
 		it('Built-in emoji string', function() {
 			const test_str = '🦊';
-			const interaction = makeInteractionWithEmoji(test_str);
+			const interaction = makeInteractionWithOpt(test_str);
 			const emoji = Options.getEmoji(interaction, test_opt_name);
 			expect(emoji).to.be.a.string;
 			expect(emoji).to.equal(test_str);
@@ -563,7 +556,7 @@ describe('Option resolvers', function() {
 			// on the fly, so we need to make a fake guild and set up all those
 			// links, too.
 			// https://github.com/discordjs/discord.js/blob/13.3.1/src/client/Client.js#L194
-			const interaction = makeInteractionWithEmoji(test_str);
+			const interaction = makeInteractionWithOpt(test_str);
 			const test_guild = new Guild(interaction.client, {
 				channels: [true], // Dumb hack.
 			});

--- a/test.js
+++ b/test.js
@@ -512,8 +512,12 @@ describe('Option resolvers', function() {
 			});
 		}
 
-		// TODO Our mock command interaction isn't smart enough for this.
-		it('Required but not provided');
+		it('Required but not provided', function() {
+			const interaction = makeInteractionWithEmoji(undefined);
+			expect(
+				() => Options.getEmoji(interaction, test_opt_name, true)
+			).to.throw(TypeError, /expected a non-empty value/);
+		});
 
 		it('Optional and not provided', function() {
 			const interaction = makeInteractionWithEmoji(undefined);


### PR DESCRIPTION
Add an emoji option resolver.

This is similar to the Application option resolver, except this one does both built-in and custom emojis.
I also updated the option resolvers to respect the `required` flag that Discord.js uses.