### PR TITLE
(bugfix) Allow matching Emojis by raw Discord IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,6 +365,7 @@ async function getApplication(interaction, opt_name, required=false) {
 
 const DEFAULT_EMOJI_PATTERN = /^\p{Emoji}+/u;
 const CUSTOM_EMOJI_PATTERN = /^<a?:[^:]+:(\d{17,22})>$/;
+const DISCORD_ID_PATTERN = /^\d{17,22}$/;
 
 /**
  * Resolves a string interaction option into a single emoji. Built-in emojis are
@@ -383,7 +384,12 @@ const CUSTOM_EMOJI_PATTERN = /^<a?:[^:]+:(\d{17,22})>$/;
 function getEmoji(interaction, opt_name, required=false) {
 	const emoji_str = interaction.options.getString(opt_name, required) || '';
 
+	// This matches built-in emojis AND Discord IDs, so we need a another check.
 	if (emoji_str.match(DEFAULT_EMOJI_PATTERN)) {
+		if (emoji_str.match(DISCORD_ID_PATTERN)) {
+			return interaction.client.emojis.resolve(emoji_str);
+		}
+
 		return emoji_str;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-command-registry",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-command-registry",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A structure for Discord.js slash commands that allow you to define, register, and execute slash commands all in one place.",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -576,7 +576,7 @@ describe('Option resolvers', function() {
 			});
 		});
 
-		it('Custom emoji string', function() {
+		describe('Custom emojis', function() {
 			const test_id = '884481185005326377';
 			const test_name = 'fennec_fox';
 			const test_str = `<:${test_name}:${test_id}>`;
@@ -586,20 +586,35 @@ describe('Option resolvers', function() {
 			// on the fly, so we need to make a fake guild and set up all those
 			// links, too.
 			// https://github.com/discordjs/discord.js/blob/13.3.1/src/client/Client.js#L194
-			const interaction = makeInteractionWithOpt(test_str);
-			const test_guild = new Guild(interaction.client, {
-				channels: [true], // Dumb hack.
-			});
-			const test_emoji = new GuildEmoji(interaction.client,
-				{ id: test_id, name: test_name },
-				test_guild
-			);
-			test_guild.emojis.cache.set(test_id, test_emoji);
-			interaction.client.guilds.cache.set(test_guild.id, test_guild);
+			function addTestEmojiToClient(interaction) {
+				const test_guild = new Guild(interaction.client, {
+					channels: [true], // Dumb hack.
+				});
+				const test_emoji = new GuildEmoji(interaction.client,
+					{ id: test_id, name: test_name },
+					test_guild
+				);
+				test_guild.emojis.cache.set(test_id, test_emoji);
+				interaction.client.guilds.cache.set(test_guild.id, test_guild);
+			}
 
-			const emoji = Options.getEmoji(interaction, test_opt_name);
-			expect(emoji).to.be.instanceOf(GuildEmoji)
-			expect(emoji.toString()).to.equal(test_str);
+			it('Custom emoji by raw Discord ID', function() {
+				const interaction = makeInteractionWithOpt(test_id);
+				addTestEmojiToClient(interaction)
+
+				const emoji = Options.getEmoji(interaction, test_opt_name);
+				expect(emoji).to.be.instanceOf(GuildEmoji);
+				expect(emoji.toString()).to.equal(test_str);
+			});
+
+			it('Custom emoji string', function() {
+				const interaction = makeInteractionWithOpt(test_str);
+				addTestEmojiToClient(interaction);
+
+				const emoji = Options.getEmoji(interaction, test_opt_name);
+				expect(emoji).to.be.instanceOf(GuildEmoji)
+				expect(emoji.toString()).to.equal(test_str);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Turns out the Emoji regex matcher also picks up Discord IDs. This meant we were returning a Discord ID, but as a raw string. I believe older versions of Discord.js allowed reacting via raw IDs, but that doesn't seem to be the case anymore.

Regardless, we now resolve raw IDs into actual `GuildEmoji` objects.

(My TypeScript friends are probably crying right now...)