### PR TITLE
Add script for registering commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ await commands.registerCommands({
 });
 ```
 
-You can also store the `application_id` and `token` in the registry to avoid
-repeating it:
+You can also store the `application_id`, `guild_id`, and `token` in the
+registry to avoid repeating it:
 
 ```js
 commands
     .setApplicationID('your bot client ID')
+    .setGuildId('your guild ID')
     .setToken('your bot token here');
 
 commands.registerCommands({ commands: ['ping'] });

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ src="https://www.gnu.org/graphics/lgplv3-with-text-154x68.png">
 _**NOTE: version 2.x of this library supports discord.js v14. If you still need
 v13 support, use an older 1.x version of this library.**_
 
-This is a data structure that lets you define Discord.js slash commands,
-register them with Discord's API, and route Discord.js Interaction events to
-your handler for that command.
+## What is this?
+
+Discord.js Command Registry is a data structure that lets you define Discord.js
+slash commands, register them with Discord's API, and route Discord.js
+Interaction events to your handler for that command.
+
+## Why should I use this?
 
 Currently Discord.js separates slash command creation into three different,
 weirdly disjoined processes. They want you to:
@@ -21,14 +25,18 @@ which uses an entirely separate library that directly relies on the Discord API
 which still requires you to write your own router and juggle your own handlers
 
 This library simplifies this process by letting you do this all in one place.
+You can:
+1. [Define your commands using builders](#defining-commands-with-the-slashcommandregistry)
+2. [Register your commands directly from the builder](#registering-commands-with-discord)
+3. [Execute handlers for your interactions directly from the builder](#executing-commands)
 
-It also provides some bridging functionality to support additional option types:
+It also supports some additional "option" types
 - Application
 - Emoji
 
-## Usage
+# Usage
 
-### Defining commands with the `SlashCommandRegistry`
+## Defining commands with the `SlashCommandRegistry`
 
 This library adds a new builder `SlashCommandRegistry` that serves as the
 entry point for defining all of your commands. Existing builders from
@@ -81,10 +89,41 @@ const commands = new SlashCommandRegistry()
     );
 ```
 
-### Registering commands with Discord
+## Registering commands with Discord
 
-The `SlashCommandRegistry` can register commands with Discord's API with a
-single function call.
+This library gives you a lot of flexibility with registration.
+
+### Using the script
+
+If you put your `SlashCommandRegistry` in its own file and make it the default
+export, you can use the script included with this library.
+
+```js
+// src/commands.js
+// Define your SlashCommandRegistry as the default export in its own file.
+const commands = new SlashCommandRegistry();
+module.exports = commands;
+```
+
+```sh
+# If your app ID and token are set in commands.js:
+npm exec register src/commands.js
+
+# If your app ID and token are defined in a config file:
+# NOTE: don't forget the -- to pass args to the script!
+npm exec register src/commands.js -- --config path/to/my/config.json
+
+# If you want to pass app ID and token in directly:
+# You can provide token as a string or a file, but you should prefer files to
+# avoid printing your token in your shell.
+npm exec register src/commands.js -- --app 1234 --token path/to/token_file
+npm exec register src/commands.js -- --app 1234 --token "my token text"
+```
+
+### Using `SlashCommandRegistry.registerCommands()`
+
+If you want more control over registration, the `SlashCommandRegistry` can
+register commands with Discord's API with a single function call.
 
 ```js
 commands.registerCommands({
@@ -97,7 +136,7 @@ commands.registerCommands({
 .catch(err => console.error('Something went wrong', err));
 ```
 
-Ok cool, but what if you need more control? You also can restrict this to
+Ok cool, but what if you need even more control? You also can restrict this to
 register only a subset of commands.
 
 ```js
@@ -126,7 +165,7 @@ commands
 commands.registerCommands({ commands: ['ping'] });
 ```
 
-### Executing commands
+## Executing commands
 
 You can pipe Discord.js interaction events directly into a
 `SlashCommandRegistry`'s `execute()` method.
@@ -150,7 +189,7 @@ This library does not do anything with the `Interaction` object other than route
 it to the appropriate handler function. It's up to you to extract relevant data
 (such as options) from the `Interaction`.
 
-### Which handler gets called?
+## Which handler gets called?
 
 I added a handler to a subcommand, the group that subcommand belongs to, the
 command that group belongs to, and to the registry itself. Which one actually
@@ -168,7 +207,7 @@ In other words, if your command and subcommand both have a handler, only the
 subcommand's handler will be called. Using a lower-priority handler can give you
 some flexibility if you have many commands that all use similar code.
 
-### Additional option types
+## Additional option types
 
 Discord (and Discord.js) does not currently support command options for things
 like Applications. This library provides functions to approximate these
@@ -217,14 +256,7 @@ included directly (preventing the need to add / import `@discordjs/builders`).
 const { bold, hyperlink, time } = require('discord-command-registry');
 ```
 
-## Dependencies
-
-This library is built using the following libraries:
-
-- Node 16.9.0 (or above)
-- [discord.js 14.x](https://discord.js.org/#/docs/discord.js/14.9.0/general/welcome)
-
-## License
+# License
 
 Copyright 2021 [Mimickal](https://github.com/Mimickal)
 

--- a/index.js
+++ b/index.js
@@ -80,6 +80,11 @@ class SlashCommandRegistry {
 	default_handler = null;
 
 	/**
+	 * A Discord guild ID used to restrict command registration to one guild.
+	 */
+	guild_id = null;
+
+	/**
 	 * The bot token used to register commands with Discord's API.
 	 */
 	token = null;
@@ -175,6 +180,18 @@ class SlashCommandRegistry {
 		}
 
 		this.default_handler = handler;
+		return this;
+	}
+
+	/**
+	 * Sets the Discord guild ID. This restricts command registration to the
+	 * given guild, rather than registering globally.
+	 *
+	 * @param {Snowflake} id The Discord guild ID.
+	 * @returns {SlashCommandRegistry} instance so we can chain calls.
+	 */
+	setGuildId(id) {
+		this.guild_id = id;
 		return this;
 	}
 
@@ -300,9 +317,9 @@ class SlashCommandRegistry {
 	 *     only these commands will be registered with the API. This can be
 	 *     useful for only registering new commands. If omitted, all commands
 	 *     are registered.
-	 * - {@link Snowflake} `guild` - A Discord Guild ID. If provided, commands
-	 *     will be registered for a specific guild instead of globally. This can
-	 *     be useful for testing commands.
+	 * - {@link Snowflake} `guild` - A Discord Guild ID. If specified, this ID
+	 *     will override the one specified via
+	 *     {@link SlashCommandRegistry.setGuildId} for this call.
 	 * - {@link String} `token` - A Discord bot token. If specified, this token
 	 *     will override the one specified via
 	 *     {@link SlashCommandRegistry.setToken} for this call.
@@ -321,9 +338,10 @@ class SlashCommandRegistry {
 
 		try {
 			const app_id = options.application_id || this.application_id;
+			const guild_id = options.guild || this.guild_id;
 			return await this.#rest.put(
-				options.guild
-					? Routes.applicationGuildCommands(app_id, options.guild)
+				guild_id
+					? Routes.applicationGuildCommands(app_id, guild_id)
 					: Routes.applicationCommands(app_id),
 				{ body: this.toJSON(options.commands) },
 			);

--- a/index.js
+++ b/index.js
@@ -19,20 +19,15 @@
 const {
 	Application,
 	BaseInteraction,
+	ContextMenuCommandBuilder,
 	Snowflake,
 	CommandInteraction,
-} = require('discord.js');
-const { REST } = require('@discordjs/rest');
-const {
-	ApplicationCommandType,
+	REST,
 	Routes,
-} = require('discord-api-types/v10');
-const {
-	ContextMenuCommandBuilder,
 	SlashCommandBuilder,
 	SlashCommandSubcommandBuilder,
 	SlashCommandSubcommandGroupBuilder,
-} = require('@discordjs/builders');
+} = require('discord.js');
 
 const API_VERSION = '10';
 
@@ -435,7 +430,6 @@ module.exports = {
 		getEmoji,
 	}),
 	...require('@discordjs/builders'), // Forward utils and stuff
-	ApplicationCommandType, // For context menu builder
 	SlashCommandRegistry,
 	SlashCommandBuilder,
 	SlashCommandSubcommandBuilder,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "discord-command-registry",
       "version": "2.0.0",
       "license": "LGPL-3.0",
+      "dependencies": {
+        "commander": "^10.0.1"
+      },
       "devDependencies": {
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
@@ -971,6 +974,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -3619,6 +3630,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "discord-command-registry",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-command-registry",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "LGPL-3.0",
       "dependencies": {
         "commander": "^10.0.1"
+      },
+      "bin": {
+        "register": "register.js"
       },
       "devDependencies": {
         "chai": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "description": "A structure for Discord.js slash commands that allow you to define, register, and execute slash commands all in one place.",
   "main": "index.js",
+  "bin": {
+    "register": "./register.js"
+  },
   "scripts": {
     "test": "mocha test.js",
     "test:coverage": "nyc --reporter=text mocha test.js"
@@ -25,6 +28,7 @@
   ],
   "files": [
     "index.js",
+    "register.js",
     "test.js"
   ],
   "author": "Mimickal",
@@ -37,5 +41,8 @@
     "chai-as-promised": "^7.1.1",
     "mocha": "^9.2.2",
     "nyc": "^15.1.0"
+  },
+  "dependencies": {
+    "commander": "^10.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-command-registry",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A structure for Discord.js slash commands that allow you to define, register, and execute slash commands all in one place.",
   "main": "index.js",
   "bin": {

--- a/register.js
+++ b/register.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/*******************************************************************************
+ * This file is part of discord-command-registry, a Discord.js slash command
+ * library for Node.js
+ * Copyright (C) 2021 Mimickal (Mia Moretti).
+ *
+ * discord-command-registry is free software under the GNU Lesser General Public
+ * License v3.0. See LICENSE.md or
+ * <https://www.gnu.org/licenses/lgpl-3.0.en.html> for more information.
+ ******************************************************************************/
+const { lstatSync, readFileSync } = require('fs');
+const { resolve } = require('path');
+const { Command } = require('commander');
+
+const cliArgs = new Command()
+	.description([
+		'Registers a SlashCommandRegistry\'s commands with Discord\'s API.',
+		'This only needs to be done once after commands are updated. Updating',
+		'commands globally can take some time to propagate! For testing, use',
+		'guild-specific commands (specify \'guild\').',
+	].join(' '))
+	.argument('<registry>',
+		'Path to a JavaScript file whose default export is a SlashCommandRegistry.',
+		require,
+	)
+	.option('-a, --app <string>', 'The Discord bot application ID.')
+	.option('-c, --config <path>',
+		'Load other options from JSON config file.\n' +
+		'Keys match names of options for this script.',
+		(path) => {
+			const config = require(resolve(path));
+			const extras = Object.keys(config).filter(
+				key => !['app', 'guild', 'token'].includes(key)
+			);
+			if (extras.length > 0) {
+				console.info('Ignoring extra config values:', extras.join(', '));
+			}
+			return config;
+		},
+	)
+	.option('-g, --guild <string>', 'A Discord guild ID.')
+	.option('-t, --token <string|path>',
+		'Path to a token file OR a raw token string.\n' +
+		'ALERT: Using a file is highly recommended to avoid printing token in your shell history!',
+		(value) => {
+			const stat = lstatSync(value, {throwIfNoEntry: false});
+			return stat?.isFile()
+				? readFileSync(resolve(value)).toString()
+				: value;
+		},
+	)
+	.parse(process.argv);
+
+const registry = cliArgs.processedArgs[0];
+
+const application_id = (
+	cliArgs.getOptionValue('app') ??
+	cliArgs.getOptionValue('config')?.app ??
+	registry.application_id
+);
+const guild = (
+	cliArgs.getOptionValue('guild') ??
+	cliArgs.getOptionValue('config')?.guild ??
+	registry.guild_id
+);
+
+if (!application_id) {
+	console.error('Error: Could not determine Application ID! Specify via config or CLI option.');
+	process.exit(1);
+}
+
+console.info([
+	`Registering commands for application '${application_id}' `,
+	guild ? `in guild '${guild}'` : 'GLOBALLY',
+	'...',
+].join(''));
+
+registry.registerCommands({
+	application_id,
+	guild,
+	token: (
+		cliArgs.getOptionValue('token') ??
+		cliArgs.getOptionValue('config')?.token
+	),
+}).then(data => {
+	console.debug(data);
+	console.debug();
+	console.info('Registration successful!', guild
+		? `Commands in Guild '${guild}' should be available immediately.`
+		: 'Commands may take some time to globally propagate.'
+	);
+
+}).catch(err => {
+	console.error('Error registering commands!\n\n', err);
+	process.exit(1);
+});

--- a/register.js
+++ b/register.js
@@ -39,6 +39,7 @@ const cliArgs = new Command()
 		},
 	)
 	.option('-g, --guild <string>', 'A Discord guild ID.')
+	.option('-n, --names <string...>', 'Only register these commands.')
 	.option('-t, --token <string|path>',
 		'Path to a token file OR a raw token string.\n' +
 		'ALERT: Using a file is highly recommended to avoid printing token in your shell history!',
@@ -82,6 +83,7 @@ registry.registerCommands({
 		cliArgs.getOptionValue('token') ??
 		cliArgs.getOptionValue('config')?.token
 	),
+	commands: cliArgs.getOptionValue('names'),
 }).then(data => {
 	console.debug(data);
 	console.debug();

--- a/register.js
+++ b/register.js
@@ -21,7 +21,7 @@ const cliArgs = new Command()
 	].join(' '))
 	.argument('<registry>',
 		'Path to a JavaScript file whose default export is a SlashCommandRegistry.',
-		require,
+		(path) => require(resolve(path)),
 	)
 	.option('-a, --app <string>', 'The Discord bot application ID.')
 	.option('-c, --config <path>',

--- a/test.js
+++ b/test.js
@@ -238,7 +238,9 @@ describe('SlashCommandRegistry registerCommands()', function() {
 		this.app_id = 'test_app_id';
 		this.token = 'test_token';
 		this.registry = new SlashCommandRegistry()
-			.setApplicationId(this.app_id).setToken(this.token);
+			.setApplicationId(this.app_id)
+			.setGuildId(null)
+			.setToken(this.token);
 
 		captured_path = null;
 		captured_headers = null;
@@ -252,6 +254,15 @@ describe('SlashCommandRegistry registerCommands()', function() {
 			.to.equal(`/api/v10/applications/${this.app_id}/commands`);
 		expect(captured_headers.authorization)
 			.to.equal(`Bot ${this.token}`);
+	});
+
+	it('Providing guild registers as guild commands', async function() {
+		const guild = 'test_guild_id';
+		makeMockApiWithCode(200);
+		await this.registry.setGuildId(guild).registerCommands();
+		expect(captured_path).to.equal(
+			`/api/v10/applications/${this.app_id}/guilds/${guild}/commands`
+		);
 	});
 
 	it('Uses application ID override', async function() {
@@ -276,12 +287,15 @@ describe('SlashCommandRegistry registerCommands()', function() {
 			.to.equal(`Bot ${this.token}`);
 	});
 
-	it('Providing guild registers as guild commands', async function() {
-		const guild = 'test_guild_id';
+	it('Uses guild ID override', async function() {
+		const newGuild = 'override';
 		makeMockApiWithCode(200);
-		await this.registry.registerCommands({ guild: guild });
+		await this.registry
+			.setGuildId('original_guild')
+			.registerCommands({ guild: newGuild });
+
 		expect(captured_path).to.equal(
-			`/api/v10/applications/${this.app_id}/guilds/${guild}/commands`
+			`/api/v10/applications/${this.app_id}/guilds/${newGuild}/commands`
 		);
 	});
 


### PR DESCRIPTION
I've used this library in several bots now, and each time I have used the same script to wrap the `SlashCommandRegistry.registerCommands()` call.

This PR adds a fairly robust script that should handle most standard command registration needs.