### PR TITLE
Fix TypeScript type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-command-registry",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-command-registry",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "LGPL-3.0",
       "dependencies": {
         "commander": "^10.0.1"
@@ -25,7 +25,7 @@
         "nyc": "^15.1.0",
         "ts-mixer": "^6.0.3",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.4"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -438,70 +438,79 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.1.tgz",
-      "integrity": "sha512-CCcLwn/8ANhlAbhlE18fcaN0hfXTen53/JiwZs1t9oE/Cqa9maA8ZRarkCIsXF4J7J/MYnd0J6IsxeKsq+f6mw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
+      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
       "peer": true,
       "dependencies": {
-        "@discordjs/formatters": "^0.3.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/shapeshift": "^3.8.1",
-        "discord-api-types": "^0.37.37",
+        "@discordjs/formatters": "^0.3.2",
+        "@discordjs/util": "^1.0.1",
+        "@sapphire/shapeshift": "^3.9.2",
+        "discord-api-types": "0.37.50",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.1"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.0.tgz",
-      "integrity": "sha512-suyVndkEAAWrGxyw/CPGdtXoRRU6AUNkibtnbJevQzpelkJh3Q1gQqWDpqf5i39CnAn5+LrN0YS+cULeEjq2Yw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "peer": true,
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.0.tgz",
-      "integrity": "sha512-Fc4MomalbP8HMKEMor3qUiboAKDtR7PSBoPjwm7WYghVRwgJlj5WYvUsriLsxeKk8+Qq2oy+HJlGTUkGvX0YnA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
+      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
       "peer": true,
       "dependencies": {
-        "discord-api-types": "^0.37.37"
+        "discord-api-types": "0.37.50"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
+      "integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
+      "peer": true,
+      "dependencies": {
+        "@discordjs/collection": "^1.5.1",
+        "@discordjs/util": "^0.3.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@sapphire/snowflake": "^3.4.2",
+        "discord-api-types": "^0.37.41",
+        "file-type": "^18.3.0",
+        "tslib": "^2.5.0",
+        "undici": "^5.22.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
-    "node_modules/@discordjs/rest": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.0.tgz",
-      "integrity": "sha512-r2HzmznRIo8IDGYBWqQfkEaGN1LrFfWQd3dSyC4tOpMU8nuVvFUEw6V/lwnG44jyOq+vgyDny2fxeUDMt9I4aQ==",
+    "node_modules/@discordjs/rest/node_modules/@discordjs/util": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
+      "integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
       "peer": true,
-      "dependencies": {
-        "@discordjs/collection": "^1.5.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.0",
-        "discord-api-types": "^0.37.37",
-        "file-type": "^18.2.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.21.0"
-      },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
-      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
+      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
       "peer": true,
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -639,9 +648,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.0.tgz",
-      "integrity": "sha512-iJpHmjAdwX9aSL6MvFpVyo+tkokDtInmSjoJHbz/k4VJfnim3DjvG0hgGEKWtWZgCu45RaLgcoNgR1fCPdIz3w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
+      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
@@ -652,9 +661,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.2.tgz",
-      "integrity": "sha512-KJwlv5gkGjs1uFV7/xx81n3tqgBwBJvH94n1xDyH3q+JSmtsMeSleJffarEBfG2yAFeJiFA4BnGOK6FFPHc19g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
       "peer": true,
       "engines": {
         "node": ">=v14.0.0",
@@ -719,9 +728,9 @@
       "peer": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -1211,9 +1220,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.39",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.39.tgz",
-      "integrity": "sha512-hkhQsQyzsTJITp311WXvHZh9j4RAMfIk2hPmsWeOTN50QTpg6zqmJNfel9D/8lYNvsU01wzw9281Yke8NhYyHg==",
+      "version": "0.37.50",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
+      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg==",
       "peer": true
     },
     "node_modules/discord.js": {
@@ -1236,6 +1245,15 @@
         "undici": "^5.21.0",
         "ws": "^8.13.0"
       },
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/discord.js/node_modules/@discordjs/util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1298,9 +1316,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/file-type": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
-      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
+      "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
       "peer": true,
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.2",
@@ -2854,9 +2872,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "peer": true
     },
     "node_modules/type-detect": {
@@ -2887,22 +2905,22 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
       "peer": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -3423,55 +3441,63 @@
       }
     },
     "@discordjs/builders": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.1.tgz",
-      "integrity": "sha512-CCcLwn/8ANhlAbhlE18fcaN0hfXTen53/JiwZs1t9oE/Cqa9maA8ZRarkCIsXF4J7J/MYnd0J6IsxeKsq+f6mw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
+      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
       "peer": true,
       "requires": {
-        "@discordjs/formatters": "^0.3.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/shapeshift": "^3.8.1",
-        "discord-api-types": "^0.37.37",
+        "@discordjs/formatters": "^0.3.2",
+        "@discordjs/util": "^1.0.1",
+        "@sapphire/shapeshift": "^3.9.2",
+        "discord-api-types": "0.37.50",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.1"
       }
     },
     "@discordjs/collection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.0.tgz",
-      "integrity": "sha512-suyVndkEAAWrGxyw/CPGdtXoRRU6AUNkibtnbJevQzpelkJh3Q1gQqWDpqf5i39CnAn5+LrN0YS+cULeEjq2Yw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "peer": true
     },
     "@discordjs/formatters": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.0.tgz",
-      "integrity": "sha512-Fc4MomalbP8HMKEMor3qUiboAKDtR7PSBoPjwm7WYghVRwgJlj5WYvUsriLsxeKk8+Qq2oy+HJlGTUkGvX0YnA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
+      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
       "peer": true,
       "requires": {
-        "discord-api-types": "^0.37.37"
+        "discord-api-types": "0.37.50"
       }
     },
     "@discordjs/rest": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.0.tgz",
-      "integrity": "sha512-r2HzmznRIo8IDGYBWqQfkEaGN1LrFfWQd3dSyC4tOpMU8nuVvFUEw6V/lwnG44jyOq+vgyDny2fxeUDMt9I4aQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
+      "integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
       "peer": true,
       "requires": {
-        "@discordjs/collection": "^1.5.0",
-        "@discordjs/util": "^0.2.0",
+        "@discordjs/collection": "^1.5.1",
+        "@discordjs/util": "^0.3.0",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.0",
-        "discord-api-types": "^0.37.37",
-        "file-type": "^18.2.1",
+        "@sapphire/snowflake": "^3.4.2",
+        "discord-api-types": "^0.37.41",
+        "file-type": "^18.3.0",
         "tslib": "^2.5.0",
-        "undici": "^5.21.0"
+        "undici": "^5.22.0"
+      },
+      "dependencies": {
+        "@discordjs/util": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
+          "integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
+          "peer": true
+        }
       }
     },
     "@discordjs/util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
-      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
+      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
       "peer": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -3580,18 +3606,18 @@
       "peer": true
     },
     "@sapphire/shapeshift": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.0.tgz",
-      "integrity": "sha512-iJpHmjAdwX9aSL6MvFpVyo+tkokDtInmSjoJHbz/k4VJfnim3DjvG0hgGEKWtWZgCu45RaLgcoNgR1fCPdIz3w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
+      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       }
     },
     "@sapphire/snowflake": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.2.tgz",
-      "integrity": "sha512-KJwlv5gkGjs1uFV7/xx81n3tqgBwBJvH94n1xDyH3q+JSmtsMeSleJffarEBfG2yAFeJiFA4BnGOK6FFPHc19g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
       "peer": true
     },
     "@tokenizer/token": {
@@ -3652,9 +3678,9 @@
       "peer": true
     },
     "@types/ws": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "peer": true,
       "requires": {
         "@types/node": "*"
@@ -4025,9 +4051,9 @@
       "dev": true
     },
     "discord-api-types": {
-      "version": "0.37.39",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.39.tgz",
-      "integrity": "sha512-hkhQsQyzsTJITp311WXvHZh9j4RAMfIk2hPmsWeOTN50QTpg6zqmJNfel9D/8lYNvsU01wzw9281Yke8NhYyHg==",
+      "version": "0.37.50",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
+      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg==",
       "peer": true
     },
     "discord.js": {
@@ -4049,6 +4075,14 @@
         "tslib": "^2.5.0",
         "undici": "^5.21.0",
         "ws": "^8.13.0"
+      },
+      "dependencies": {
+        "@discordjs/util": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+          "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
+          "peer": true
+        }
       }
     },
     "electron-to-chromium": {
@@ -4093,9 +4127,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "file-type": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
-      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
+      "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
       "peer": true,
       "requires": {
         "readable-web-to-node-stream": "^3.0.2",
@@ -5208,9 +5242,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "peer": true
     },
     "type-detect": {
@@ -5235,15 +5269,15 @@
       }
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "undici": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
       "peer": true,
       "requires": {
         "busboy": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-command-registry",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A structure for Discord.js slash commands that allow you to define, register, and execute slash commands all in one place.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -55,7 +55,7 @@
     "nyc": "^15.1.0",
     "ts-mixer": "^6.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "commander": "^10.0.1"

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -32,7 +32,7 @@ import * as Discord from 'discord.js';
 import { Mixin } from 'ts-mixer';
 import { s } from '@sapphire/shapeshift';
 
-const { name: pack_name } = require('../package.json');
+const { name: PACKAGE_NAME } = require('../package.json');
 
 /** Either a Builder or a function that returns a Builder. */
 export type BuilderInput<T> = T | ((thing: T) => T);
@@ -200,7 +200,7 @@ export function assertReturnOfBuilder<T, P>(
 ): asserts input is T {
 	if (!(input instanceof ExpectedInstanceOf)) {
 		throw new Error(ParentInstanceOf && input instanceof ParentInstanceOf
-			? `Use ${ExpectedInstanceOf.name} from ${pack_name}, not discord.js`
+			? `Use ${ExpectedInstanceOf.name} from ${PACKAGE_NAME}, not discord.js`
 			: `input did not resolve to a ${ExpectedInstanceOf.name}. Got ${input}`
 		);
 	}

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -98,21 +98,6 @@ class CommandHandlerMixin<T extends Discord.CommandInteraction> {
 	}
 }
 
-/**
- * Discord.js builders are not designed to be grouped together in a collection.
- * This union represents any possible end value for an individual command's
- * builder.
- */
-export type SlashCommandBuilderReturn =
-	| SlashCommandBuilder
-	| Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>
-	| SlashCommandSubcommandsOnlyBuilder;
-
-type SlashCommandSubcommandsOnlyBuilder = Omit<SlashCommandBuilder,
-	| Exclude<keyof Discord.SharedSlashCommandOptions, 'options'>
-	| keyof MoreOptionsMixin
->;
-
 // NOTE: it's important that Discord's built-ins are the last Mixin in the list!
 // Otherwise, we run the risk of stepping on field initialization.
 

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -44,7 +44,8 @@ export type SlashCommandCustomOption = Omit<Discord.SlashCommandStringOption,
 >;
 
 /** Mixin that adds builder support for our additional custom options. */
-class MoreOptionsMixin extends Discord.SharedSlashCommandOptions {
+class MoreOptionsMixin<ShouldOmitSubcommandFunctions = true>
+extends Discord.SharedSlashCommandOptions<ShouldOmitSubcommandFunctions> {
 	/**
 	 * Adds an Application option.
 	 *
@@ -125,25 +126,23 @@ export class ContextMenuCommandBuilder extends Mixin(
 
 export class SlashCommandBuilder extends Mixin(
 	CommandHandlerMixin<Discord.ChatInputCommandInteraction>,
-	MoreOptionsMixin,
+	MoreOptionsMixin<false>,
 	Discord.SlashCommandBuilder,
 ) {
-	// @ts-ignore We want to force this to only accept our version of the
+	// @ts-expect-error We want to force this to only accept our version of the
 	// builder with .setHandler.
-	addSubcommand(
-		input: BuilderInput<SlashCommandSubcommandBuilder>
-	): SlashCommandSubcommandsOnlyBuilder {
+	addSubcommand(input: BuilderInput<SlashCommandSubcommandBuilder>): this {
 		return addThing(this, input,
 			SlashCommandSubcommandBuilder,
 			Discord.SlashCommandSubcommandBuilder
 		);
 	}
 
-	// @ts-ignore We want to force this to only accept our version of the
+	// @ts-expect-error We want to force this to only accept our version of the
 	// builder with .setHandler.
 	addSubcommandGroup(
 		input: BuilderInput<SlashCommandSubcommandGroupBuilder>
-	): SlashCommandSubcommandsOnlyBuilder {
+	): this {
 		return addThing(this, input,
 			SlashCommandSubcommandGroupBuilder,
 			Discord.SlashCommandSubcommandGroupBuilder,
@@ -155,7 +154,7 @@ export class SlashCommandSubcommandGroupBuilder extends Mixin(
 	CommandHandlerMixin<Discord.ChatInputCommandInteraction>,
 	Discord.SlashCommandSubcommandGroupBuilder,
 ) {
-	// @ts-ignore We want to force this to only accept our version of the
+	// @ts-expect-error We want to force this to only accept our version of the
 	// builder with .setHandler.
 	addSubcommand(input: BuilderInput<SlashCommandSubcommandBuilder>): this {
 		return addThing(this, input,
@@ -166,7 +165,7 @@ export class SlashCommandSubcommandGroupBuilder extends Mixin(
 }
 
 export class SlashCommandSubcommandBuilder extends Mixin(
-	MoreOptionsMixin,
+	MoreOptionsMixin<false>,
 	CommandHandlerMixin<Discord.ChatInputCommandInteraction>,
 	Discord.SlashCommandSubcommandBuilder,
 ) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@
 export * from '@discordjs/builders'; // Forward utils and stuff
 export {
 	ContextMenuCommandBuilder,
+	Handler,
 	SlashCommandBuilder,
 	SlashCommandCustomOption,
 	SlashCommandSubcommandBuilder,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -104,7 +104,7 @@ export default class SlashCommandRegistry {
 	 * @throws If input does not resolve to a SlashCommandBuilder.
 	 * @return Instance so we can chain calls.
 	 */
-	addCommand(input: BuilderInput<SlashCommandBuilderReturn>): this {
+	addCommand(input: BuilderInput<SlashCommandBuilder>): this {
 		const builder = resolveBuilder(input, SlashCommandBuilder);
 		assertReturnOfBuilder(builder,
 			SlashCommandBuilder,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -11,15 +11,15 @@ import {
 	BaseInteraction,
 	ChatInputCommandInteraction,
 	CommandInteraction,
+	ContextMenuCommandBuilder as DiscordContextMenuCommandBuilder,
 	ContextMenuCommandInteraction,
 	DiscordAPIError,
-	ContextMenuCommandBuilder as DiscordContextMenuCommandBuilder,
-	SlashCommandBuilder as DiscordSlashCommandBuilder,
 	REST,
-	Routes,
-	Snowflake,
-	RESTPostAPIContextMenuApplicationCommandsJSONBody,
 	RESTPostAPIChatInputApplicationCommandsJSONBody,
+	RESTPostAPIContextMenuApplicationCommandsJSONBody,
+	Routes,
+	SlashCommandBuilder as DiscordSlashCommandBuilder,
+	Snowflake,
 } from 'discord.js';
 
 import {
@@ -29,14 +29,12 @@ import {
 	Handler,
 	resolveBuilder,
 	SlashCommandBuilder,
-	SlashCommandBuilderReturn,
 	SlashCommandSubcommandBuilder,
 	SlashCommandSubcommandGroupBuilder,
 } from './builders';
 import { API_VERSION } from './constants';
 
-/** A top-level command builder. */
-type TopLevelBuilder = SlashCommandBuilderReturn | ContextMenuCommandBuilder;
+type TopLevelBuilder = ContextMenuCommandBuilder | SlashCommandBuilder
 
 /** Optional parameters for registering commands. */
 interface RegisterOpts {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -10,6 +10,7 @@
 import {
 	BaseInteraction,
 	ChatInputCommandInteraction,
+	CommandInteraction,
 	ContextMenuCommandInteraction,
 	DiscordAPIError,
 	ContextMenuCommandBuilder as DiscordContextMenuCommandBuilder,
@@ -19,7 +20,6 @@ import {
 	Snowflake,
 	RESTPostAPIContextMenuApplicationCommandsJSONBody,
 	RESTPostAPIChatInputApplicationCommandsJSONBody,
-	CommandInteraction,
 } from 'discord.js';
 
 import {
@@ -77,7 +77,7 @@ export default class SlashCommandRegistry {
 	application_id: Snowflake | null = null;
 
 	/** The handler run for unrecognized commands. */
-	default_handler: Handler | null = null;
+	default_handler: Handler<CommandInteraction> | null = null;
 
 	/** A Discord guild ID used to restrict command registration to one guild. */
 	guild_id: Snowflake | null = null;
@@ -154,7 +154,7 @@ export default class SlashCommandRegistry {
 	 * @throws If handler is not a function.
 	 * @return Instance so we can chain calls.
 	 */
-	setDefaultHandler(handler: Handler): this {
+	setDefaultHandler(handler: Handler<CommandInteraction>): this {
 		if (typeof handler !== 'function') {
 			throw new Error(`handler was '${typeof handler}', expected 'function'`);
 		}
@@ -297,6 +297,11 @@ export default class SlashCommandRegistry {
 			builder_top.handler    ??
 			this.default_handler;
 
+		// @ts-expect-error Discord.js Interaction types are mutually exclusive,
+		// despite all extending BaseInteraction. We do our best to make sure
+		// each individual handler is the right type, but the union of all of
+		// them here resolves to "never".
+		// https://discord.com/channels/222078108977594368/824411059443204127/1145960025962066033
 		return handler ? handler(interaction) as T : undefined;
 	}
 

--- a/test/builders.test.ts
+++ b/test/builders.test.ts
@@ -17,15 +17,29 @@ import {
 	SlashCommandBuilder,
 	SlashCommandSubcommandBuilder,
 	SlashCommandSubcommandGroupBuilder,
+	SlashCommandRegistry,
 } from '../src';
 import { BuilderInput } from '../src/builders';
 
 type CanSetHandler = new () => {
-	setHandler: (handler: Handler) => unknown;
+	setHandler: (handler: Handler<Discord.CommandInteraction>) => unknown;
 }
 type CanAddSubCommand = new () => {
 	addSubcommand: (input: BuilderInput<SlashCommandSubcommandBuilder>) => unknown;
 };
+
+// These are static type tests to ensure Handler can accept all of these types.
+new SlashCommandRegistry()
+	.addContextMenuCommand(cmd => cmd
+		.setType(Discord.ApplicationCommandType.User)
+		.setHandler((int: Discord.UserContextMenuCommandInteraction) => {})
+		.setHandler((int: Discord.MessageContextMenuCommandInteraction) => {})
+	)
+	.addCommand(cmd => cmd
+		.setHandler((int: Discord.CommandInteraction) => {})
+		.setHandler((int: Discord.ChatInputCommandInteraction) => {})
+	)
+	.setDefaultHandler((int: Discord.CommandInteraction) => {})
 
 describe('Builders have setHandler() functions injected', function() {
 	Array.of<CanSetHandler>(

--- a/test/builders.test.ts
+++ b/test/builders.test.ts
@@ -30,16 +30,29 @@ type CanAddSubCommand = new () => {
 
 // These are static type tests to ensure Handler can accept all of these types.
 new SlashCommandRegistry()
+	// Can accept all ContextMenuCommandInteraction types
 	.addContextMenuCommand(cmd => cmd
 		.setType(Discord.ApplicationCommandType.User)
 		.setHandler((int: Discord.UserContextMenuCommandInteraction) => {})
 		.setHandler((int: Discord.MessageContextMenuCommandInteraction) => {})
 	)
+	// Can accept ChatInputCommandInteractions
 	.addCommand(cmd => cmd
 		.setHandler((int: Discord.CommandInteraction) => {})
 		.setHandler((int: Discord.ChatInputCommandInteraction) => {})
 	)
+	// Can accept a fallback handler
 	.setDefaultHandler((int: Discord.CommandInteraction) => {})
+	// Can accept commands with options
+	.addCommand(cmd => cmd
+		.addChannelOption(opt => opt)
+	)
+	// Can accept subcommands with options
+	.addCommand(cmd => cmd
+		.addSubcommand(sub => sub
+			.addChannelOption(opt => opt)
+		)
+	)
 
 describe('Builders have setHandler() functions injected', function() {
 	Array.of<CanSetHandler>(

--- a/test/builders.test.ts
+++ b/test/builders.test.ts
@@ -12,12 +12,13 @@ import * as Discord from 'discord.js';
 
 import {
 	ContextMenuCommandBuilder,
+	Handler,
 	SlashCommandCustomOption,
 	SlashCommandBuilder,
 	SlashCommandSubcommandBuilder,
 	SlashCommandSubcommandGroupBuilder,
 } from '../src';
-import { BuilderInput, Handler } from '../src/builders';
+import { BuilderInput } from '../src/builders';
 
 type CanSetHandler = new () => {
 	setHandler: (handler: Handler) => unknown;

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -71,6 +71,7 @@ export class MockCommandInteraction extends ChatInputCommandInteraction {
 				username: 'fake_test_user',
 				discriminator: '1234',
 				avatar: null,
+				global_name: null,
 			},
 		});
 


### PR DESCRIPTION
This release fixes some scenarios where TypeScript would report type incompatibilities in builders.
- `.addXOption` functions from Discord.js now preserve type information.
- Handler functions now determine `interaction` type better.
- Handler functions don't cause TypeScript errors anymore (no idea how I didn't catch this the first time around).