### PR TITLE
Command handler decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const {
 } = require('discord-command-registry');
 
 const commands = new SlashCommandRegistry()
-    .addDefaultHandler(interaction => interaction.reply("I can't do this yet"))
+    .setDefaultHandler(interaction => interaction.reply("I can't do this yet"))
     .addCommand(command => command
         .setName('ping')
         .setDescription('Ping pong command')
@@ -294,8 +294,8 @@ const {
 
 const commands = new SlashCommandRegistry()
     .addCommand(command => command
-        .addName('mycmd')
-        .addDescription('Example command that has an application option')
+        .setName('mycmd')
+        .setDescription('Example command that has an application option')
         // New function this library adds. Uses string options under the hood.
         .addApplicationOption(option => option
             .setName('app')

--- a/README.md
+++ b/README.md
@@ -114,17 +114,17 @@ module.exports = commands;
 
 ```sh
 # If your app ID and token are set in commands.js:
-npm exec register src/commands.js
+npx register src/commands.js
 
 # If your app ID and token are defined in a config file:
 # NOTE: don't forget the -- to pass args to the script!
-npm exec register src/commands.js -- --config path/to/my/config.json
+npx register src/commands.js -- --config path/to/my/config.json
 
 # If you want to pass app ID and token in directly:
 # You can provide token as a string or a file, but you should prefer files to
 # avoid printing your token in your shell.
-npm exec register src/commands.js -- --app 1234 --token path/to/token_file
-npm exec register src/commands.js -- --app 1234 --token "my token text"
+npx register src/commands.js -- --app 1234 --token path/to/token_file
+npx register src/commands.js -- --app 1234 --token "my token text"
 ```
 
 ### Using the script with TypeScript
@@ -133,9 +133,19 @@ If you're using TypeScript and aren't transpiling to JavaScript (e.g. running
 your bot with `ts-node`), you can still use this script. This library ships
 with a separate, stand-alone TypeScript version of this register script.
 
+Like the JavaScript version, put your `SlashCommandRegistry` in its own file
+and make it the default export:
+
+```ts
+// src/commands.ts
+// Define your SlashCommandRegistry as the default export in its own file.
+const commands = new SlashCommandRegistry();
+export default commands;
+```
+
 Then you can run the register script from `node_modules` like this:
 ```sh
-npx ts-node --esm --skipIgnore --logError --compilerOptions '{"esModuleInterop":true}' node_modules/discord-command-registry/src/register.ts
+npx ts-node --esm --skipIgnore --logError --compilerOptions '{"esModuleInterop":true,"resolveJsonModule":true}' node_modules/discord-command-registry/src/register.ts
 ```
 
 If you'd rather remove all the `ts-node` flags, you can also specify these
@@ -148,8 +158,22 @@ options in your `tsconfig.json`, like this:
         "logError": true,
         "compilerOptions": {
             "esModuleInterop": true,
+            "resolveJsonModule": true,
         }
     }
+}
+```
+
+### `--config` JSON format
+
+You can provide registration configuration from a JSON file instead of
+specifying individual flags. The following fields are supported:
+
+```json
+{
+    "token": "<your Discord bot token>",
+    "app": "<Discord bot application ID>",
+    "guild": "<ID of Discord guild to register commands in>"
 }
 ```
 
@@ -248,11 +272,14 @@ these additional option types:
 
 (Note: these are registered as string options under the hood)
 
-- `SlashCommandCustomOption`
-- `addApplicationOption(custom_option)`
-- `addEmojiOption(custom_option)`
-- `getApplication(interaction, option_name, required=false)`
-- `getEmoji(interaction, option_name, required=false)`
+- New types
+  - `SlashCommandCustomOption`
+- New builder options
+  - `addApplicationOption(custom_option)`
+  - `addEmojiOption(custom_option)`
+- Option resolvers (via `Options.getX`)
+  - `getApplication(interaction, option_name, required=false)`
+  - `getEmoji(interaction, option_name, required=false)`
 
 To use these, register the option using the appropriate custom builder, then
 use the `Options.getX(...)` helpers to retrieve the value.
@@ -269,13 +296,13 @@ const commands = new SlashCommandRegistry()
     .addCommand(command => command
         .addName('mycmd')
         .addDescription('Example command that has an application option')
-        // Add your application option as a string option
+        // New function this library adds. Uses string options under the hood.
         .addApplicationOption(option => option
             .setName('app')
             .setDescription('An application ID')
         )
         .setHandler(async (interaction) => {
-            // Use this function to resolve that string option into an application.
+            // Use this function to resolve that option into an application.
             // NOTE this makes an HTTP call and so returns a promise.
             const app = await Options.getApplication(interaction, 'app');
             return interaction.reply(`Application name: ${app.name}`);
@@ -287,7 +314,7 @@ const commands = new SlashCommandRegistry()
 
 We no longer export `@discordjs/builders` helper functions like `bold` and
 `hyperlink`. Originally, `@discordjs/builders` was a separate package, so
-forwarding its functions prevented developers from needing to add it directly.
+forwarding its functions saved developers from needing to add it directly.
 These functions have since been integrated into the parent `discord.js` package,
 so our export is no longer necessary. Just import them directly from
 `discord.js` instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-command-registry",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-command-registry",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "LGPL-3.0",
       "dependencies": {
         "@sapphire/shapeshift": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-command-registry",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A structure for Discord.js slash commands that allow you to define, register, and execute slash commands all in one place.",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -39,7 +39,7 @@
     "lib/*",
     "src/register.ts"
   ],
-  "author": "Mimickal",
+  "author": "Mimickal <mimickal.dev@gmail.com>",
   "license": "LGPL-3.0",
   "peerDependencies": {
     "@discordjs/builders": "^1.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,11 @@ export {
 	SlashCommandSubcommandGroupBuilder,
 } from './builders';
 
+import * as Middleware from './middleware';
 import * as Options from './options';
 import SlashCommandRegistry from './registry';
 export {
+	Middleware,
 	Options,
 	SlashCommandRegistry,
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of discord-command-registry, a Discord.js slash command
+ * library for Node.js
+ * Copyright (C) 2021 Mimickal (Mia Moretti).
+ *
+ * discord-command-registry is free software under the GNU Lesser General Public
+ * License v3.0. See LICENSE.md or
+ * <https://www.gnu.org/licenses/lgpl-3.0.en.html> for more information.
+ ******************************************************************************/
+import {
+	CommandInteraction,
+	Guild,
+	PermissionFlagsBits,
+} from 'discord.js';
+
+import { Handler } from './builders';
+
+/**
+ * Command handler middleware that only runs the handler if the user who
+ * initiated the interaction has the {@link PermissionFlagsBits.Administrator}
+ * permission. If the check fails, the {@link reject} handler is called instead.
+ * Implies {@link requireGuild}.
+ */
+export function requireAdmin<T extends CommandInteraction>(
+	handler: Handler<T>,
+	reject?: Handler<T>,
+): Handler<T> {
+	return async function(interaction: T): Promise<unknown> {
+		if (!interaction.inCachedGuild()) {
+			return reject?.(interaction);
+		};
+
+		const member = await interaction.member.fetch();
+
+		if (!member.permissions.has(PermissionFlagsBits.Administrator)) {
+			return reject?.(interaction);
+		}
+
+		return handler(interaction);
+	}
+}
+
+/**
+ * Command handler middleware that only runs the handler if the interaction
+ * comes from a Guild. If the check fails, the {@link reject} handler is called
+ * instead.
+ */
+export function requireGuild<T extends CommandInteraction>(
+	handler: Handler<T & { get guild(): Guild }>,
+	reject?: Handler<T>,
+): Handler<T> {
+	return function(interaction: T): unknown {
+		return interaction.inCachedGuild()
+			? handler(interaction)
+			: reject?.(interaction);
+	}
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -13,14 +13,14 @@ import { resolve } from 'path';
 import { Command } from 'commander';
 // Using require instead of import uses actual package.json
 // instead of including a copy in the generated code.
-const { version } = require('../package.json');
+const { name, version } = require('../package.json');
 
 const cliArgs = new Command()
 	.description([
 		"Registers a SlashCommandRegistry's commands with Discord's API.",
 		'This only needs to be done once after commands are updated. Updating',
 		'commands globally can take some time to propagate! For testing, use',
-		'guild-specific commands (specify "guild").',
+		'guild-specific commands (specify --guild). Guild commands propagate instantly.',
 	].join(' '))
 	.argument('<registry>',
 		'Path to a JS (or TS) file whose default export is a SlashCommandRegistry.',
@@ -41,7 +41,9 @@ const cliArgs = new Command()
 			return config;
 		},
 	)
-	.option('-g, --guild <string>', 'A Discord guild ID.')
+	.option('-g, --guild <string>',
+		'A Discord guild ID. Only register commands in this guild.'
+	)
 	.option('-n, --names <string...>', 'Only register these commands.')
 	.option('-t, --token <string|path>',
 		'Path to a token file OR a raw token string.\n' +
@@ -53,7 +55,7 @@ const cliArgs = new Command()
 				: value;
 		},
 	)
-	.version(version)
+	.version(version, '-v, --version', `Print ${name} version and exit.`)
 	.parse(process.argv);
 
 const registry = cliArgs.processedArgs[0];

--- a/src/register.ts
+++ b/src/register.ts
@@ -11,7 +11,9 @@
 import { lstatSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { Command } from 'commander';
-import { version } from '../package.json';
+// Using require instead of import uses actual package.json
+// instead of including a copy in the generated code.
+const { version } = require('../package.json');
 
 const cliArgs = new Command()
 	.description([

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -15,11 +15,14 @@ const { requireAdmin, requireGuild } = Middleware;
 
 import { MockCommandInteraction, MockGuildMember } from './mock';
 
+const STANDARD_HANDLER_MSG = 'Standard handler' as const;
+const REJECTED_HANDLER_MSG = 'Rejected handler' as const;
+
 describe('Middleware', function() {
 describe(requireAdmin.name, function() {
 	const cmd = new SlashCommandBuilder().setHandler(requireAdmin(
-		(interaction) => 'Standard handler',
-		(interaction) => 'Rejected handler',
+		(interaction) => STANDARD_HANDLER_MSG,
+		(interaction) => REJECTED_HANDLER_MSG,
 	));
 
 	it('Standard handler called for Admin user', async function() {
@@ -32,7 +35,7 @@ describe(requireAdmin.name, function() {
 		});
 
 		const result = await cmd.handler!(interaction);
-		expect(result).to.equal('Standard handler');
+		expect(result).to.equal(STANDARD_HANDLER_MSG);
 	});
 
 	it('Rejected handler called for non-Admin user', async function() {
@@ -45,7 +48,7 @@ describe(requireAdmin.name, function() {
 		});
 
 		const result = await cmd.handler!(interaction);
-		expect(result).to.equal('Rejected handler');
+		expect(result).to.equal(REJECTED_HANDLER_MSG);
 	});
 
 	it('Rejected handler called for non-Guild interaction', async function() {
@@ -55,7 +58,34 @@ describe(requireAdmin.name, function() {
 		});
 
 		const result = await cmd.handler!(interaction);
-		expect(result).to.equal('Rejected handler');
+		expect(result).to.equal(REJECTED_HANDLER_MSG);
+	});
+});
+
+describe(requireGuild.name, function() {
+	const cmd = new SlashCommandBuilder().setHandler(requireGuild(
+		(interaction) => STANDARD_HANDLER_MSG,
+		(interaction) => REJECTED_HANDLER_MSG,
+	));
+
+	it('Standard handler called for interaction in Guild', async function() {
+		const interaction = new MockCommandInteraction({
+			name: 'test',
+			is_in_guild: true,
+		});
+
+		const result = await cmd.handler!(interaction);
+		expect(result).to.equal(STANDARD_HANDLER_MSG);
+	});
+
+	it('Rejected handler called for interaction outside Guild', async function() {
+		const interaction = new MockCommandInteraction({
+			name: 'test',
+			is_in_guild: false,
+		});
+
+		const result = await cmd.handler!(interaction);
+		expect(result).to.equal(REJECTED_HANDLER_MSG);
 	});
 });
 });

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * This file is part of discord-command-registry, a Discord.js slash command
+ * library for Node.js
+ * Copyright (C) 2021 Mimickal (Mia Moretti).
+ *
+ * discord-command-registry is free software under the GNU Lesser General Public
+ * License v3.0. See LICENSE.md or
+ * <https://www.gnu.org/licenses/lgpl-3.0.en.html> for more information.
+ ******************************************************************************/
+import { expect } from 'chai';
+import { PermissionFlagsBits } from 'discord.js';
+
+import { Middleware, SlashCommandBuilder } from '../src';
+const { requireAdmin, requireGuild } = Middleware;
+
+import { MockCommandInteraction, MockGuildMember } from './mock';
+
+describe('Middleware', function() {
+describe(requireAdmin.name, function() {
+	const cmd = new SlashCommandBuilder().setHandler(requireAdmin(
+		(interaction) => 'Standard handler',
+		(interaction) => 'Rejected handler',
+	));
+
+	it('Standard handler called for Admin user', async function() {
+		const interaction = new MockCommandInteraction({
+			name: 'test',
+			is_in_guild: true,
+			member: new MockGuildMember({
+				permissions: PermissionFlagsBits.Administrator,
+			}),
+		});
+
+		const result = await cmd.handler!(interaction);
+		expect(result).to.equal('Standard handler');
+	});
+
+	it('Rejected handler called for non-Admin user', async function() {
+		const interaction = new MockCommandInteraction({
+			name: 'test',
+			is_in_guild: true,
+			member: new MockGuildMember({
+				permissions: undefined,
+			}),
+		});
+
+		const result = await cmd.handler!(interaction);
+		expect(result).to.equal('Rejected handler');
+	});
+
+	it('Rejected handler called for non-Guild interaction', async function() {
+		const interaction = new MockCommandInteraction({
+			name: 'test',
+			is_in_guild: false,
+		});
+
+		const result = await cmd.handler!(interaction);
+		expect(result).to.equal('Rejected handler');
+	});
+});
+});


### PR DESCRIPTION
Added `requireAdmin` and `requireGuild` command handler decorators. These handle common checks at the beginning of command handlers.

This PR also cleaned up some minor issues in the README.